### PR TITLE
Encrypted system prompts and caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.12
 	github.com/ethersphere/bee v1.18.2
 	github.com/gin-gonic/gin v1.10.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/sashabaranov/go-openai v1.36.0
 	github.com/stretchr/testify v1.9.0
 	github.com/zde37/pinata-go-sdk v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpx
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 h1:X4egAf/gcS1zATw6wn4Ej8vjuVGxeHdan+bRb2ebyv4=
 github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -74,7 +74,7 @@ type AgentConfig struct {
 const (
 	systemPromptCacheSize = 1000
 	systemPromptCacheTTL  = 1 * time.Hour
-	systemPromptMaxSize   = 20480
+	systemPromptMaxSize   = 5000
 )
 
 func NewAgent(ctx context.Context, config *AgentConfig) (*Agent, error) {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,7 +1,9 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"io"
@@ -43,6 +45,8 @@ type Agent struct {
 	apiRouter    *gin.Engine
 	httpClient   *http.Client
 
+	rsaPrivateKey *rsa.PrivateKey
+
 	factoryAddress  common.Address
 	pollingInterval time.Duration
 	apiIpPort       string
@@ -66,6 +70,11 @@ type AgentConfig struct {
 func NewAgent(ctx context.Context, config *AgentConfig) (*Agent, error) {
 	if config == nil {
 		return nil, errors.New("config is nil")
+	}
+
+	rsaPrivateKey, err := rsa.GenerateKey(bytes.NewReader(config.PrivateKeySeed), 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate rsa private key: %w", err)
 	}
 
 	indexer, err := indexer.NewIndexer(indexer.IndexerOptions{
@@ -98,6 +107,8 @@ func NewAgent(ctx context.Context, config *AgentConfig) (*Agent, error) {
 		tappdClient:  config.TappdClient,
 		apiRouter:    nil,
 		httpClient:   config.HttpClient,
+
+		rsaPrivateKey: rsaPrivateKey,
 
 		factoryAddress:  config.FactoryAddress,
 		pollingInterval: config.PollingInterval,

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3,6 +3,8 @@ package agent_test
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -26,6 +28,8 @@ import (
 	contractYayoiFactory "github.com/NethermindEth/yayois-garden/pkg/bindings/YayoiFactory"
 )
 
+var rsaPrivateKey, _ = rsa.GenerateKey(rand.Reader, 2048)
+
 var genesisAccount, _ = crypto.GenerateKey()
 var genesisAddress = crypto.PubkeyToAddress(genesisAccount.PublicKey)
 
@@ -37,8 +41,8 @@ var userAccount, _ = crypto.GenerateKey()
 var userAddress = crypto.PubkeyToAddress(userAccount.PublicKey)
 var userAuth, _ = bind.NewKeyedTransactorWithChainID(userAccount, big.NewInt(1337))
 
-var agentPrivateKeySeed = []byte("test-seed")
-var agentWallet, _ = wallet.NewWallet(agentPrivateKeySeed, big.NewInt(1337))
+var agentPrivateKeySeed = [2048]byte{}
+var agentWallet, _ = wallet.NewWallet(agentPrivateKeySeed[:], big.NewInt(1337))
 var agentAddress = agentWallet.Address()
 
 type mockArtGenerator struct {
@@ -98,14 +102,15 @@ func TestNewAgent(t *testing.T) {
 		{
 			name: "valid config",
 			agentConfig: &agent.AgentConfig{
-				ArtGenerator:    &mockArtGenerator{},
-				Uploader:        &mockUploader{},
-				EthClient:       mockEthClient,
-				TappdClient:     &mockTappdClient{},
-				FactoryAddress:  common.HexToAddress("0x1234567890123456789012345678901234567890"),
-				PollingInterval: 5 * time.Second,
-				PrivateKeySeed:  agentPrivateKeySeed,
-				ApiIpPort:       "",
+				ArtGenerator:          &mockArtGenerator{},
+				Uploader:              &mockUploader{},
+				EthClient:             mockEthClient,
+				TappdClient:           &mockTappdClient{},
+				FactoryAddress:        common.HexToAddress("0x1234567890123456789012345678901234567890"),
+				PollingInterval:       5 * time.Second,
+				AccountPrivateKeySeed: agentPrivateKeySeed[:],
+				RsaPrivateKey:         rsaPrivateKey,
+				ApiIpPort:             "",
 			},
 			wantErr: false,
 		},
@@ -134,14 +139,15 @@ func TestAgent_Start(t *testing.T) {
 	mockEthClient, _ := newMockEthClient()
 
 	agentConfig := &agent.AgentConfig{
-		ArtGenerator:    &mockArtGenerator{},
-		Uploader:        &mockUploader{},
-		EthClient:       mockEthClient,
-		TappdClient:     &mockTappdClient{},
-		FactoryAddress:  common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		PollingInterval: 5 * time.Second,
-		PrivateKeySeed:  agentPrivateKeySeed,
-		ApiIpPort:       "",
+		ArtGenerator:          &mockArtGenerator{},
+		Uploader:              &mockUploader{},
+		EthClient:             mockEthClient,
+		TappdClient:           &mockTappdClient{},
+		FactoryAddress:        common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		PollingInterval:       5 * time.Second,
+		AccountPrivateKeySeed: agentPrivateKeySeed[:],
+		RsaPrivateKey:         rsaPrivateKey,
+		ApiIpPort:             "",
 	}
 
 	agent, err := agent.NewAgent(context.Background(), agentConfig)
@@ -178,14 +184,15 @@ func TestAgent_Quote(t *testing.T) {
 	}
 
 	agentConfig := &agent.AgentConfig{
-		ArtGenerator:    &mockArtGenerator{},
-		Uploader:        &mockUploader{},
-		EthClient:       mockEthClient,
-		TappdClient:     mockTappdClient,
-		FactoryAddress:  common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		PollingInterval: 5 * time.Second,
-		PrivateKeySeed:  agentPrivateKeySeed,
-		ApiIpPort:       "",
+		ArtGenerator:          &mockArtGenerator{},
+		Uploader:              &mockUploader{},
+		EthClient:             mockEthClient,
+		TappdClient:           mockTappdClient,
+		FactoryAddress:        common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		PollingInterval:       5 * time.Second,
+		AccountPrivateKeySeed: agentPrivateKeySeed[:],
+		RsaPrivateKey:         rsaPrivateKey,
+		ApiIpPort:             "",
 	}
 
 	a, err = agent.NewAgent(context.Background(), agentConfig)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -204,137 +205,269 @@ func TestAgent_Quote(t *testing.T) {
 }
 
 func TestAgent_MainFlow(t *testing.T) {
-	mockEthClient, simBackend := newMockEthClient()
+	t.Run("plain text system prompt", func(t *testing.T) {
+		mockEthClient, simBackend := newMockEthClient()
 
-	factoryAddr, tx, factoryInstance, err := contractYayoiFactory.DeployContractYayoiFactory(
-		ownerAuth,
-		mockEthClient,
-		common.HexToAddress("0x0000000000000000000000000000000000000000"),
-		big.NewInt(10),
-		ownerAddress,
-	)
-	require.NoError(t, err)
-	simBackend.Commit()
+		factoryAddr, tx, factoryInstance, err := contractYayoiFactory.DeployContractYayoiFactory(
+			ownerAuth,
+			mockEthClient,
+			common.HexToAddress("0x0000000000000000000000000000000000000000"),
+			big.NewInt(10),
+			ownerAddress,
+		)
+		require.NoError(t, err)
+		simBackend.Commit()
 
-	require.NotEqual(t, factoryAddr, common.Address{}, "Factory address should not be zero")
-	require.NotNil(t, factoryInstance, "Factory instance should not be nil")
-	require.NotNil(t, tx, "Should have a valid deploy transaction")
+		require.NotEqual(t, factoryAddr, common.Address{}, "Factory address should not be zero")
+		require.NotNil(t, factoryInstance, "Factory instance should not be nil")
+		require.NotNil(t, tx, "Should have a valid deploy transaction")
 
-	tx2, err := factoryInstance.UpdateAuthorizedSigner(ownerAuth, agentAddress, true)
-	require.NoError(t, err)
-	simBackend.Commit()
-	require.NotNil(t, tx2, "Should have a valid transaction updating the authorized signer")
+		tx2, err := factoryInstance.UpdateAuthorizedSigner(ownerAuth, agentAddress, true)
+		require.NoError(t, err)
+		simBackend.Commit()
+		require.NotNil(t, tx2, "Should have a valid transaction updating the authorized signer")
 
-	tx2Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx2)
-	require.NoError(t, err)
-	require.NotNil(t, tx2Receipt, "Should have a valid transaction receipt")
+		tx2Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx2)
+		require.NoError(t, err)
+		require.NotNil(t, tx2Receipt, "Should have a valid transaction receipt")
 
-	systemPrompt := "test system prompt"
-	systemPromptUri := "ipfs://demo"
-	userPrompt := "test user prompt"
-	artUri := "test-art-uri"
-	uploadedArtUri := "test-uploaded-art-uri"
-	uploadedJsonUri := "test-uploaded-json-uri"
-	collectionName := "test-collection-name"
-	collectionSymbol := "TEST"
+		systemPrompt := "test system prompt"
+		systemPromptUri := "ipfs://demo"
+		userPrompt := "test user prompt"
+		artUri := "test-art-uri"
+		uploadedArtUri := "test-uploaded-art-uri"
+		uploadedJsonUri := "test-uploaded-json-uri"
+		collectionName := "test-collection-name"
+		collectionSymbol := "TEST"
 
-	mockHttpClient := &http.Client{
-		Transport: &mockHttpTransport{
-			roundTrip: func(req *http.Request) (*http.Response, error) {
-				if req.URL.String() == systemPromptUri {
-					return &http.Response{
-						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewBufferString(systemPrompt)),
-					}, nil
-				}
-				return nil, fmt.Errorf("unexpected request to %s", req.URL)
-			},
-		},
-	}
-
-	tx3Params := *ownerAuth
-	tx3Params.Value = big.NewInt(10)
-
-	tx3, err := factoryInstance.CreateCollection(&tx3Params, contractYayoiFactory.YayoiFactoryCreateCollectionParams{
-		Name:                  collectionName,
-		Symbol:                collectionSymbol,
-		SystemPromptUri:       systemPromptUri,
-		PaymentToken:          common.Address{},
-		PromptSubmissionPrice: big.NewInt(20),
-	})
-	require.NoError(t, err)
-	simBackend.Commit()
-	require.NotNil(t, tx2, "Should have a valid transaction creating a collection")
-
-	tx3Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx3)
-	require.NoError(t, err)
-	require.NotNil(t, tx3Receipt, "Should have a valid transaction receipt")
-
-	testAgent := setupTestAgent(t, func(config *agent.AgentConfig) {
-		config.EthClient = mockEthClient
-		config.HttpClient = mockHttpClient
-		config.FactoryAddress = factoryAddr
-		config.PollingInterval = 1 * time.Second
-		config.ArtGenerator = &mockArtGenerator{
-			generateUrl: func(ctx context.Context, prompt string, systemPrompt string) (string, error) {
-				require.Equal(t, prompt, userPrompt)
-				require.Equal(t, systemPrompt, systemPrompt)
-
-				return artUri, nil
+		mockHttpClient := &http.Client{
+			Transport: &mockHttpTransport{
+				roundTrip: func(req *http.Request) (*http.Response, error) {
+					if req.URL.String() == systemPromptUri {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(bytes.NewBufferString(systemPrompt)),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL)
+				},
 			},
 		}
-		config.Uploader = &mockUploader{
-			uploadUrl: func(ctx context.Context, url string) (string, error) {
-				require.Equal(t, url, artUri)
 
-				return uploadedArtUri, nil
-			},
-			uploadJson: func(ctx context.Context, json interface{}) (string, error) {
-				require.Equal(t, json, map[string]string{
-					"name":        collectionName,
-					"description": userPrompt,
-					"image":       uploadedArtUri,
-				})
+		tx3Params := *ownerAuth
+		tx3Params.Value = big.NewInt(10)
 
-				return uploadedJsonUri, nil
-			},
-		}
+		tx3, err := factoryInstance.CreateCollection(&tx3Params, contractYayoiFactory.YayoiFactoryCreateCollectionParams{
+			Name:                  collectionName,
+			Symbol:                collectionSymbol,
+			SystemPromptUri:       systemPromptUri,
+			PaymentToken:          common.Address{},
+			PromptSubmissionPrice: big.NewInt(20),
+		})
+		require.NoError(t, err)
+		simBackend.Commit()
+		require.NotNil(t, tx3, "Should have a valid transaction creating a collection")
+
+		tx3Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx3)
+		require.NoError(t, err)
+		require.NotNil(t, tx3Receipt, "Should have a valid transaction receipt")
+
+		testAgent := setupTestAgent(t, func(config *agent.AgentConfig) {
+			config.EthClient = mockEthClient
+			config.HttpClient = mockHttpClient
+			config.FactoryAddress = factoryAddr
+			config.PollingInterval = 1 * time.Second
+			config.ArtGenerator = &mockArtGenerator{
+				generateUrl: func(ctx context.Context, prompt string, systemPrompt string) (string, error) {
+					require.Equal(t, prompt, userPrompt)
+					require.Equal(t, systemPrompt, systemPrompt)
+					return artUri, nil
+				},
+			}
+			config.Uploader = &mockUploader{
+				uploadUrl: func(ctx context.Context, url string) (string, error) {
+					require.Equal(t, url, artUri)
+					return uploadedArtUri, nil
+				},
+				uploadJson: func(ctx context.Context, json interface{}) (string, error) {
+					require.Equal(t, json, map[string]string{
+						"name":        collectionName,
+						"description": userPrompt,
+						"image":       uploadedArtUri,
+					})
+					return uploadedJsonUri, nil
+				},
+			}
+		})
+
+		agentCtx, agentCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		go func() {
+			err := testAgent.Start(agentCtx)
+			require.Error(t, err, context.DeadlineExceeded)
+		}()
+
+		collectionAddr, err := factoryInstance.GetCollectionFromSystemPromptUri(nil, systemPromptUri)
+		require.NoError(t, err)
+		require.NotEqual(t, collectionAddr, common.Address{})
+
+		collectionInstance, err := contractYayoiCollection.NewContractYayoiCollection(collectionAddr, mockEthClient)
+		require.NoError(t, err)
+		require.NotNil(t, collectionInstance)
+
+		tx4Params := *userAuth
+		tx4Params.Value = big.NewInt(20)
+
+		tx4, err := collectionInstance.SuggestPrompt(&tx4Params, userPrompt)
+		require.NoError(t, err)
+		simBackend.Commit()
+		require.NotNil(t, tx4, "Should have a valid transaction suggesting a prompt")
+
+		tx4Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx4)
+		require.NoError(t, err)
+		require.NotNil(t, tx4Receipt, "Should have a valid transaction receipt")
+
+		<-agentCtx.Done()
+		agentCancel()
+
+		simBackend.Commit()
+
+		token0, err := collectionInstance.TokenURI(nil, big.NewInt(0))
+		require.NoError(t, err)
+		require.Equal(t, token0, uploadedJsonUri)
 	})
 
-	agentCtx, agentCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	go func() {
-		err := testAgent.Start(agentCtx)
-		require.Error(t, err, context.DeadlineExceeded)
-	}()
+	t.Run("encrypted system prompt", func(t *testing.T) {
+		mockEthClient, simBackend := newMockEthClient()
 
-	collectionAddr, err := factoryInstance.GetCollectionFromSystemPromptUri(nil, systemPromptUri)
-	require.NoError(t, err)
-	require.NotEqual(t, collectionAddr, common.Address{})
+		// Deploy a new factory
+		factoryAddr, tx, factoryInstance, err := contractYayoiFactory.DeployContractYayoiFactory(
+			ownerAuth,
+			mockEthClient,
+			common.HexToAddress("0x0000000000000000000000000000000000000000"),
+			big.NewInt(10),
+			ownerAddress,
+		)
+		require.NoError(t, err)
+		simBackend.Commit()
 
-	collectionInstance, err := contractYayoiCollection.NewContractYayoiCollection(collectionAddr, mockEthClient)
-	require.NoError(t, err)
-	require.NotNil(t, collectionInstance)
+		require.NotEqual(t, factoryAddr, common.Address{}, "Factory address should not be zero")
+		require.NotNil(t, factoryInstance, "Factory instance should not be nil")
+		require.NotNil(t, tx, "Should have a valid deploy transaction")
 
-	tx4Params := *userAuth
-	tx4Params.Value = big.NewInt(20)
+		// Authorize the agent
+		tx2, err := factoryInstance.UpdateAuthorizedSigner(ownerAuth, agentAddress, true)
+		require.NoError(t, err)
+		simBackend.Commit()
+		require.NotNil(t, tx2, "Should have a valid transaction updating the authorized signer")
 
-	tx4, err := collectionInstance.SuggestPrompt(&tx4Params, userPrompt)
-	require.NoError(t, err)
-	simBackend.Commit()
-	require.NotNil(t, tx4, "Should have a valid transaction suggesting a prompt")
+		tx2Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx2)
+		require.NoError(t, err)
+		require.NotNil(t, tx2Receipt, "Should have a valid transaction receipt")
 
-	tx4Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx4)
-	require.NoError(t, err)
-	require.NotNil(t, tx4Receipt, "Should have a valid transaction receipt")
+		systemPromptDecrypted := "test system prompt (decrypted)"
+		systemPromptUri := "ipfs://demo-encrypted"
+		userPrompt := "test user prompt"
+		artUri := "test-art-uri"
+		uploadedArtUri := "test-uploaded-art-uri"
+		uploadedJsonUri := "test-uploaded-json-uri"
+		collectionName := "test-collection-name-encrypted"
+		collectionSymbol := "TESTE"
 
-	<-agentCtx.Done()
-	agentCancel()
+		systemPromptEncrypted, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, &rsaPrivateKey.PublicKey, []byte(systemPromptDecrypted), nil)
+		require.NoError(t, err)
 
-	simBackend.Commit()
+		mockHttpClient := &http.Client{
+			Transport: &mockHttpTransport{
+				roundTrip: func(req *http.Request) (*http.Response, error) {
+					if req.URL.String() == systemPromptUri {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(bytes.NewBuffer(systemPromptEncrypted)),
+						}, nil
+					}
+					return nil, fmt.Errorf("unexpected request to %s", req.URL)
+				},
+			},
+		}
 
-	token0, err := collectionInstance.TokenURI(nil, big.NewInt(0))
-	require.NoError(t, err)
-	require.Equal(t, token0, uploadedJsonUri)
+		tx3Params := *ownerAuth
+		tx3Params.Value = big.NewInt(10)
+		tx3, err := factoryInstance.CreateCollection(&tx3Params, contractYayoiFactory.YayoiFactoryCreateCollectionParams{
+			Name:                  collectionName,
+			Symbol:                collectionSymbol,
+			SystemPromptUri:       systemPromptUri,
+			PaymentToken:          common.Address{},
+			PromptSubmissionPrice: big.NewInt(20),
+		})
+		require.NoError(t, err)
+		simBackend.Commit()
+		require.NotNil(t, tx3, "Should have a valid transaction creating a collection")
+
+		tx3Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx3)
+		require.NoError(t, err)
+		require.NotNil(t, tx3Receipt, "Should have a valid transaction receipt")
+
+		testAgent := setupTestAgent(t, func(config *agent.AgentConfig) {
+			config.EthClient = mockEthClient
+			config.HttpClient = mockHttpClient
+			config.FactoryAddress = factoryAddr
+			config.PollingInterval = 1 * time.Second
+			config.ArtGenerator = &mockArtGenerator{
+				generateUrl: func(ctx context.Context, prompt string, systemPrompt string) (string, error) {
+					require.Equal(t, prompt, userPrompt)
+					require.Equal(t, systemPromptDecrypted, systemPrompt)
+					return artUri, nil
+				},
+			}
+			config.Uploader = &mockUploader{
+				uploadUrl: func(ctx context.Context, url string) (string, error) {
+					require.Equal(t, url, artUri)
+					return uploadedArtUri, nil
+				},
+				uploadJson: func(ctx context.Context, json interface{}) (string, error) {
+					require.Equal(t, json, map[string]string{
+						"name":        collectionName,
+						"description": userPrompt,
+						"image":       uploadedArtUri,
+					})
+					return uploadedJsonUri, nil
+				},
+			}
+		})
+
+		agentCtx, agentCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		go func() {
+			err := testAgent.Start(agentCtx)
+			require.Error(t, err, context.DeadlineExceeded)
+		}()
+
+		collectionAddr, err := factoryInstance.GetCollectionFromSystemPromptUri(nil, systemPromptUri)
+		require.NoError(t, err)
+		require.NotEqual(t, collectionAddr, common.Address{})
+
+		collectionInstance, err := contractYayoiCollection.NewContractYayoiCollection(collectionAddr, mockEthClient)
+		require.NoError(t, err)
+		require.NotNil(t, collectionInstance)
+
+		tx4Params := *userAuth
+		tx4Params.Value = big.NewInt(20)
+		tx4, err := collectionInstance.SuggestPrompt(&tx4Params, userPrompt)
+		require.NoError(t, err)
+		simBackend.Commit()
+		require.NotNil(t, tx4, "Should have a valid transaction suggesting a prompt")
+
+		tx4Receipt, err := bind.WaitMined(context.Background(), simBackend.Client(), tx4)
+		require.NoError(t, err)
+		require.NotNil(t, tx4Receipt, "Should have a valid transaction receipt")
+
+		<-agentCtx.Done()
+		agentCancel()
+		simBackend.Commit()
+
+		token0, err := collectionInstance.TokenURI(nil, big.NewInt(0))
+		require.NoError(t, err)
+		require.Equal(t, token0, uploadedJsonUri)
+	})
 }
 
 type mockHttpTransport struct {

--- a/pkg/agent/api.go
+++ b/pkg/agent/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
@@ -17,7 +18,11 @@ func (a *Agent) generateRouter() *gin.Engine {
 	})
 
 	router.GET("/pubkey", func(c *gin.Context) {
-		c.JSON(http.StatusOK, a.rsaPrivateKey.PublicKey)
+		pubKey := a.RsaPublicKey()
+		c.JSON(http.StatusOK, map[string]string{
+			"n": pubKey.N.String(),
+			"e": strconv.Itoa(pubKey.E),
+		})
 	})
 
 	router.GET("/quote", func(c *gin.Context) {

--- a/pkg/agent/api.go
+++ b/pkg/agent/api.go
@@ -16,6 +16,10 @@ func (a *Agent) generateRouter() *gin.Engine {
 		c.String(http.StatusOK, a.Address().String())
 	})
 
+	router.GET("/pubkey", func(c *gin.Context) {
+		c.JSON(http.StatusOK, a.rsaPrivateKey.PublicKey)
+	})
+
 	router.GET("/quote", func(c *gin.Context) {
 		quote, err := a.Quote(c.Request.Context())
 		if err != nil {

--- a/pkg/agent/setup/setup.go
+++ b/pkg/agent/setup/setup.go
@@ -37,7 +37,11 @@ func Setup(ctx context.Context) (*SetupResult, error) {
 	setupResult, err := loadSetup(ctx, config)
 	if err != nil {
 		slog.Warn("failed to load setup, initializing new setup", "error", err)
-		return initializeSetup(ctx, config)
+
+		setupResult, err = initializeSetup(ctx, config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize setup: %v", err)
+		}
 	}
 
 	if debug.IsDebugShowSetup() {

--- a/pkg/agent/setup/setup.go
+++ b/pkg/agent/setup/setup.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"context"
 	"crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,15 +16,16 @@ import (
 )
 
 type SetupResult struct {
-	DstackTappdEndpoint string
-	EthereumRpcUrl      string
-	FactoryAddress      common.Address
-	SecureFile          string
-	OpenAiApiKey        string
-	OpenAiModel         string
-	PinataJwtKey        string
-	ApiIpPort           string
-	PrivateKeySeed      []byte
+	DstackTappdEndpoint   string
+	EthereumRpcUrl        string
+	FactoryAddress        common.Address
+	SecureFile            string
+	OpenAiApiKey          string
+	OpenAiModel           string
+	PinataJwtKey          string
+	ApiIpPort             string
+	AccountPrivateKeySeed []byte
+	RsaPrivateKey         *rsa.PrivateKey
 }
 
 func Setup(ctx context.Context) (*SetupResult, error) {
@@ -46,21 +48,27 @@ func Setup(ctx context.Context) (*SetupResult, error) {
 }
 
 func generateSetup(config *Config) (*SetupResult, error) {
-	privateKeySeed := make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, privateKeySeed); err != nil {
+	accountPrivateKeySeed := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, accountPrivateKeySeed); err != nil {
 		return nil, fmt.Errorf("failed to generate private key seed: %v", err)
 	}
 
+	rsaPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate rsa private key: %w", err)
+	}
+
 	return &SetupResult{
-		DstackTappdEndpoint: config.DstackTappdEndpoint,
-		EthereumRpcUrl:      config.EthereumRpcUrl,
-		FactoryAddress:      common.HexToAddress(config.FactoryAddress),
-		SecureFile:          config.SecureFile,
-		OpenAiApiKey:        config.OpenAiApiKey,
-		OpenAiModel:         config.OpenAiModel,
-		PinataJwtKey:        config.PinataJwtKey,
-		ApiIpPort:           config.ApiIpPort,
-		PrivateKeySeed:      privateKeySeed,
+		DstackTappdEndpoint:   config.DstackTappdEndpoint,
+		EthereumRpcUrl:        config.EthereumRpcUrl,
+		FactoryAddress:        common.HexToAddress(config.FactoryAddress),
+		SecureFile:            config.SecureFile,
+		OpenAiApiKey:          config.OpenAiApiKey,
+		OpenAiModel:           config.OpenAiModel,
+		PinataJwtKey:          config.PinataJwtKey,
+		ApiIpPort:             config.ApiIpPort,
+		AccountPrivateKeySeed: accountPrivateKeySeed,
+		RsaPrivateKey:         rsaPrivateKey,
 	}, nil
 }
 

--- a/pkg/agent/wallet/wallet.go
+++ b/pkg/agent/wallet/wallet.go
@@ -44,3 +44,7 @@ func (w *Wallet) Address() common.Address {
 func (w *Wallet) Auth() *bind.TransactOpts {
 	return w.auth
 }
+
+func (w *Wallet) Seed() []byte {
+	return w.seed
+}


### PR DESCRIPTION
This PR adds support for encrypted system prompts. The user needs to encrypt their document with the RSA pubkey exposed by the agent, which will then try and decrypt it. Both plaintext and encrypted can be handled in the same way.
An LRU cache for system prompts was also added, and we're now checking the prompt size through a HEAD call before actually processing it to avoid getting DoSed.